### PR TITLE
Multiply Hit Rate by 100 to calculate expected percentage value

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -335,7 +335,16 @@ namespace PRTG_Redis_Sensor
                                 channel = "Hit Rate",
                                 unit = PRTGUnit.Percent,
                                 Float=1,
-                                value = SafeGetFloat(() => (Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) / (Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) + Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_misses")).Value))).ToString())
+                                value = SafeGetFloat(() => 
+                                    (
+                                        100.0 * 
+                                        Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) / 
+                                        (
+                                            Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) +
+                                            Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_misses")).Value)
+                                        )
+                                    ).ToString()
+                                )
                             }
                         },
                         {


### PR DESCRIPTION
The hit rate metric right now calculates a ratio and not a percentage as expected by PRTG. This multiplies the result of the current calculation by 100 to get the expected percent value and address issue #27.

I also broke the calculation out into multiple lines so it is easier to read as it was getting very long.