### PR TITLE
New functionalities: command line arguments + retrieve cache values

### DIFF
--- a/CommandLineOptions.cs
+++ b/CommandLineOptions.cs
@@ -1,0 +1,26 @@
+﻿using CommandLine;
+using PRTG_Redis_Sensor.Enums;
+
+namespace PRTG_Redis_Sensor
+{
+	public class CommandLineOptions
+	{
+		[Option('t', "Monitor type", Required = true, HelpText = "Indicates the type of monitor to execute.\r\n")]
+		public MonitorServiceEnum Type { get; set; }
+
+		[Option('e', "Redis endpoints", Required = true, HelpText = "Specify the redis endpoints (i.e. server1:port;server2:port)")]
+		public string EndPoints { get; set; }
+
+		[Option('p', "Redis password", Required = false, HelpText = "Specify the redis password if required")]
+		public string Password { get; set; }
+
+		[Option('d', "Database index", Required = false, HelpText = "Specify the database index")]
+		public int DatabaseIndex { get; set; }
+
+		[Option('k', "Cache keys", Required = false, HelpText = "Keys whose values you want to retrieve from cache (separated by pipe | )")]
+		public string CacheKeys { get; set; }
+
+		[Option('r', "Transform value", Required = false, HelpText = "Elaborate the value retrieved from cache using the specified transformation.\r\n")]
+		public MonitorCacheValueTransformEnum? Transform { get; set; }
+	}
+}

--- a/Enums/MonitorCacheValueTransformEnum.cs
+++ b/Enums/MonitorCacheValueTransformEnum.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PRTG_Redis_Sensor.Enums
+{
+	public enum MonitorCacheValueTransformEnum
+	{
+		ElapsedMinutes
+	}
+}

--- a/Enums/MonitorServiceEnum.cs
+++ b/Enums/MonitorServiceEnum.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PRTG_Redis_Sensor.Enums
+{
+	public enum MonitorServiceEnum
+	{
+		Stats,
+		CacheKeysValues
+	}
+}

--- a/Model/PRTGMonitor.cs
+++ b/Model/PRTGMonitor.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace PRTG_Redis_Sensor.Model
+{
+	public class PRTGMonitor
+	{
+
+		[JsonProperty(propertyName: "prtg")]
+		public PRTGResponse Response { get; set; }
+	}
+}

--- a/Model/PRTGResponse.cs
+++ b/Model/PRTGResponse.cs
@@ -2,8 +2,9 @@
 using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
 
-namespace PRTG_Redis_Sensor
+namespace PRTG_Redis_Sensor.Model
 {
+    //TODO: refactor, separate definitions on different files
     [JsonConverter(typeof(StringEnumConverter))]
     public enum PRTGUnit
     {

--- a/PRTG Redis Sensor.csproj
+++ b/PRTG Redis Sensor.csproj
@@ -14,6 +14,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommandLineParser" Version="2.8.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="StackExchange.Redis" Version="2.2.88" />
 	</ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -1,433 +1,61 @@
-﻿using Newtonsoft.Json;
-using StackExchange.Redis;
+﻿using CommandLine;
+using CommandLine.Text;
+using Newtonsoft.Json;
+using PRTG_Redis_Sensor.Model;
+using PRTG_Redis_Sensor.Services;
+using PRTG_Redis_Sensor.Services.Factories;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 
 namespace PRTG_Redis_Sensor
 {
-    internal class Program
-    {
-        private static void Main(string[] args)
-        {
-            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
-            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+	internal class Program
+	{
+		private static void Main(string[] arguments)
+		{
+			// TODO: refactor, main has too many lines of code
+			CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+			CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
-            ConfigurationOptions configurationOptions = new()
-            {
-                EndPoints = { { args[0] } },
-                AllowAdmin = true
-            };
+			var parser = new Parser(with =>
+			{
+				with.CaseInsensitiveEnumValues = true;
+				with.HelpWriter = null;
+			});
 
-            if (args.Length > 1)
-            {
-                configurationOptions.Password = args[1];
-            }
+			var result = parser.ParseArguments<CommandLineOptions>(arguments);
 
-            var redisConnectionMultiplexer = ConnectionMultiplexer.Connect(configurationOptions);
-            var redisServer = redisConnectionMultiplexer.GetServer(configurationOptions.EndPoints[0]);
+			result.MapResult(o =>
+			{
+				//TODO: move to a different service
+				IRedisMonitorServiceFactory factory = new RedisMonitorServiceFactory();
+				IRedisMonitorService service = null;
 
-            var info = redisServer.Info();
-            var serverInfo = info.SingleOrDefault(i => i.Key.Equals("Server", StringComparison.InvariantCultureIgnoreCase));
-            var clientsInfo = info.SingleOrDefault(i => i.Key.Equals("Clients", StringComparison.InvariantCultureIgnoreCase));
-            var memoryInfo = info.SingleOrDefault(i => i.Key.Equals("Memory", StringComparison.InvariantCultureIgnoreCase));
-            var persistenceInfo = info.SingleOrDefault(i => i.Key.Equals("Persistence", StringComparison.InvariantCultureIgnoreCase));
-            var statsInfo = info.SingleOrDefault(i => i.Key.Equals("Stats", StringComparison.InvariantCultureIgnoreCase));
-            var replicationInfo = info.SingleOrDefault(i => i.Key.Equals("Replication", StringComparison.InvariantCultureIgnoreCase));
-            var keyspaceInfo = info.SingleOrDefault(i => i.Key.Equals("Keyspace", StringComparison.InvariantCultureIgnoreCase));
-            var cpuInfo = info.SingleOrDefault(i => i.Key.Equals("CPU", StringComparison.InvariantCultureIgnoreCase));
-            var clusterInfo = info.SingleOrDefault(i => i.Key.Equals("Cluster", StringComparison.InvariantCultureIgnoreCase));
+				// create service
+				service = factory.Create(o.EndPoints, o.Password, o.DatabaseIndex, o.Type);
 
-            var response = new
-            {
-                prtg = new PRTGResponse
-                {
-                    result = new List<PRTGResult>
-                    {
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Uptime",
-                                Unit = PRTGUnit.TimeSeconds,
-                                Value = serverInfo?.SingleOrDefault(i => i.Key.Equals("uptime_in_seconds")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Connected Clients",
-                                Unit = PRTGUnit.Count,
-                                Value = clientsInfo?.SingleOrDefault(i => i.Key.Equals("connected_clients")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Blocked Clients",
-                                Unit = PRTGUnit.Count,
-                                Value = clientsInfo?.SingleOrDefault(i => i.Key.Equals("blocked_clients")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used Memory",
-                                Unit = PRTGUnit.BytesMemory,
-                                Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("used_memory")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used Memory RSS",
-                                Unit = PRTGUnit.BytesMemory,
-                                Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("used_memory_rss")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used Memory Peak",
-                                Unit = PRTGUnit.BytesMemory,
-                                Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("used_memory_peak")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Memory Fragmentation Ratio",
-                                Unit = PRTGUnit.Custom,
-                                Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("mem_fragmentation_ratio")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult()
-                            {
-                                Channel = "RDB Changes Since Last Save",
-                                Unit = PRTGUnit.Custom,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_changes_since_last_save")).Value == "ok" ? "1" : "0"
-                            }
-                        },
-                        {
-                            new PRTGResult()
-                            {
-                                Channel = "RDB Last Save Time",
-                                Unit = PRTGUnit.Custom,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_last_save_time")).Value == "ok" ? "1" : "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "RDB Last Background Save Status",
-                                Unit = PRTGUnit.Count,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_last_bgsave_status")).Value == "ok" ? "1" : "0",
-                                ShowChart = "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "RDB Last Background Save Time in Seconds",
-                                Unit = PRTGUnit.TimeSeconds,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_last_bgsave_time_sec")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "AOF Last Rewrite Time in Seconds",
-                                Unit = PRTGUnit.TimeSeconds,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("aof_last_rewrite_time_sec")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "AOF Last Background Rewrite Status",
-                                Unit = PRTGUnit.Count,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("aof_last_bgrewrite_status")).Value == "ok" ? "1" : "0",
-                                ShowChart = "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "AOF Last Write Status",
-                                Unit = PRTGUnit.Count,
-                                Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("aof_last_write_status")).Value == "ok" ? "1" : "0",
-                                ShowChart = "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Total Connections Received",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_connections_received")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Total Commands Processed",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_commands_processed")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Instantaneous Operations per Second",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("instantaneous_ops_per_sec")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult()
-                            {
-                                Channel = "Instantaneous Input kbps",
-                                Unit = PRTGUnit.BytesBandwidth,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("instantaneous_input_kbps")).Value ?? "0",
-                                //Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult()
-                            {
-                                Channel = "Instantaneous Output kbps",
-                                Unit = PRTGUnit.BytesBandwidth,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("instantaneous_output_kbps")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Total Net Input Bytes",
-                                Unit = PRTGUnit.BytesBandwidth,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_net_input_bytes")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Total Net Output Bytes",
-                                Unit = PRTGUnit.BytesBandwidth,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_net_output_bytes")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Rejected Connections",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("rejected_connections")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Pubsub Channels",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("pubsub_channels")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Pubsub Patterns",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("pubsub_patterns")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Is Master",
-                                Unit = PRTGUnit.Count,
-                                Value = replicationInfo.SingleOrDefault(i => i.Key.Equals("role")).Value.Equals("master", StringComparison.InvariantCultureIgnoreCase) ? "1" : "0",
-                                ShowChart = "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Is Replication Backlog Active",
-                                Unit = PRTGUnit.Count,
-                                Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_active")).Value ?? "0",
-                                ShowChart = "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Replication Backlog Size",
-                                Unit = PRTGUnit.BytesMemory,
-                                Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_size")).Value ?? "0"
-                            }
-                        }
-                        ,
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Replication Backlog First Size Byte Offset",
-                                Unit = PRTGUnit.BytesMemory,
-                                Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_first_byte_offset")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Replication Backlog Histlen",
-                                Unit = PRTGUnit.BytesMemory,
-                                Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_histlen")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Connected Slaves",
-                                Unit = PRTGUnit.Count,
-                                Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("connected_slaves")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Keys",
-                                Unit = PRTGUnit.Count,
-                                Value = SafeGetInt32(() => keyspaceInfo != null ? keyspaceInfo.SingleOrDefault(i => i.Key.Equals("db0")).Value.Split(',').Select(x => x.Split('=')).ToDictionary(x => x[0], x => x[1])["keys"] : "0")
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Keys Expires",
-                                Unit = PRTGUnit.Count,
-                                Value = SafeGetInt32(() => keyspaceInfo != null ? keyspaceInfo.SingleOrDefault(i => i.Key.Equals("db0")).Value.Split(',').Select(x => x.Split('=')).ToDictionary(x => x[0], x => x[1])["expires"] : "0")
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Keyspace Hits",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Keyspace Misses",
-                                Unit = PRTGUnit.Count,
-                                Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("keyspace_misses")).Value ?? "0"
-                            }
-                        },
-                        {
-                            new PRTGResult()
-                            {
-                                Channel = "Hit Rate",
-                                Unit = PRTGUnit.Percent,
-                                Value = SafeGetFloat(() => statsInfo != null ?
-                                    (
-                                        (100.0 *
-                                         Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) /
-                                         (
-                                             Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) +
-                                             Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_misses")).Value)
-                                         )) 
-                                    ).ToString() : "0"
-                                ),
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used CPU Sys",
-                                Unit = PRTGUnit.Custom,
-                                Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_sys")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used CPU User",
-                                Unit = PRTGUnit.Custom,
-                                Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_user")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used CPU Sys Children",
-                                Unit = PRTGUnit.Custom,
-                                Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_sys_children")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Used CPU User Children",
-                                Unit = PRTGUnit.Custom,
-                                Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_user_children")).Value ?? "0",
-                                Float = "1"
-                            }
-                        },
-                        {
-                            new PRTGResult
-                            {
-                                Channel = "Cluster Enabled",
-                                Unit = PRTGUnit.Count,
-                                Value = clusterInfo?.SingleOrDefault(i => i.Key.Equals("cluster_enabled")).Value ?? "0",
-                                ShowChart = "0"
-                            }
-                        }
-                    }
-                }
-            };
+				// make prtg response
+				PRTGMonitor response = service.Execute(o.CacheKeys, o.Transform); //TODO: review this interface, seems inelegant, cache keys and transform are not needed in every implementations
 
-            Console.WriteLine(JsonConvert.SerializeObject(response, Formatting.Indented, new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore
-            }));
-        }
+				// write to output
+				Console.WriteLine(JsonConvert.SerializeObject(response, Formatting.Indented, new JsonSerializerSettings
+				{
+					NullValueHandling = NullValueHandling.Ignore
+				}));
 
-        private static string SafeGetInt32(Func<string> func)
-        {
-            try
-            {
-                return func();
-            }
-            catch (Exception ex)
-            {
-                Trace.TraceError(ex.ToString());
-                return "0";
-            }
-        }
-
-        private static string SafeGetFloat(Func<string> func)
-        {
-            try
-            {
-                var result = func();
-                return result.Equals("NaN", StringComparison.InvariantCultureIgnoreCase) ? "0" : result;
-
-            }
-            catch (Exception ex)
-            {
-                Trace.TraceError(ex.ToString());
-                return "0";
-            }
-        }
-    }
+				return 1;
+			},
+			errs =>
+			{
+				var helpText = HelpText.AutoBuild(result, h =>
+				{
+					// Configure HelpText	 
+					h.AddEnumValuesToHelpText = true;
+					return h;
+				}, e => e, verbsIndex: true);
+				Console.WriteLine(helpText);
+				return 1;
+			});
+		}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -11,13 +11,54 @@ A Redis Sensor for PRTG. Read more at: https://blog.cdemi.io/monitoring-redis-in
 ## Download or Compile
 You can download the latest `PRTG.Redis.Sensor.exe` from [GitHub Releases](https://github.com/cdemi/PRTG-Redis-Sensor/releases/latest), or you can download the source-code and compile it yourself
 
-## Run the executable
-`"PRTG.Redis.Sensor.exe" <ServerIPorHostname:Port> <Password?>`
+## Run the executable (get help)
+`"PRTG.Redis.Sensor.exe" `
 
-### Example
+```
+PRTG Redis Sensor <version>
+MIT
 
-- `"PRTG.Redis.Sensor.exe" myredis.domain.local:6379`
-- `"PRTG.Redis.Sensor.exe" myredis.domain.local:6379 somepassword`
+  t, Monitor type       Required. Indicates the type of monitor to execute.
+                        Valid values: Stats, CacheKeysValues
+
+  e, Redis endpoints    Required. Specify the redis endpoints (i.e.
+                        server1:port;server2:port)
+
+  p, Redis password     Specify the redis password if required
+
+  d, Database index     Specify the database index
+
+  k, Cache keys         Keys whose values you want to retrieve from cache
+                        (separated by pipe | )
+
+  r, Transform value    Elaborate the value retrieved from cache using the
+                        specified transformation.
+                        Valid values: ElapsedMinutes
+```
+
+## Run the executable (get generic stats)
+`"PRTG.Redis.Sensor.exe" -t Stats -e <ServerIPorHostname:Port> -p <Password?>`
+
+## Run the executable (get cache keys values)
+`"PRTG.Redis.Sensor.exe" -t CacheKeysValues -e <ServerIPorHostname:Port> -p <Password?> -k key1|key2|...`
+
+## Run the executable (work on a differend database index than default one?)
+`"PRTG.Redis.Sensor.exe" -t <MonitorType> -e <ServerIPorHostname:Port> -p <Password?> -d <DatabaseIndex?>`
+
+## Retrieve a cache value and manipulate the value result
+In case of datetime cache values, as PRTG usually manages numeric values, you probably need to retrieve the amount of time elapsed from that value:
+
+`"PRTG.Redis.Sensor.exe" -t <MonitorType> -e <ServerIPorHostname:Port> -p <Password?> -d <DatabaseIndex?> -k key1 -r ElapsedMinutes`
+
+### Examples
+
+- `"PRTG.Redis.Sensor.exe" -t Stats -e myredis.domain.local:6379`
+- `"PRTG.Redis.Sensor.exe" -t Stats -e myredis.domain.local:6379 -p somepassword`
+- `"PRTG.Redis.Sensor.exe" -t CacheKeysValues -e myredis.domain.local:6379 -p somepassword -k cachekey1`
+
+### Breaking changes (starting on version 3.0)
+Note that from version 3.0 this tool will require extra arguments to properly define the input values.
+Calling the executable without parameters will give you some help on how to use it.
 
 ## Add the sensor on PRTG
 1. Copy the binary `PRTG.Redis.Sensor.exe` to the custom sensors folder of the probe `%programfiles(x86)%\PRTG Network Monitor\Custom Sensors\EXEXML\`

--- a/Services/Base/BaseRedisMonitorService.cs
+++ b/Services/Base/BaseRedisMonitorService.cs
@@ -1,0 +1,30 @@
+﻿using PRTG_Redis_Sensor.Enums;
+using PRTG_Redis_Sensor.Model;
+using StackExchange.Redis;
+using System;
+
+namespace PRTG_Redis_Sensor.Services.Base
+{
+	public abstract class BaseRedisMonitorService : IRedisMonitorService
+	{
+		protected readonly ConfigurationOptions _options;
+		protected readonly IConnectionMultiplexer _connection;
+
+		public BaseRedisMonitorService(ConfigurationOptions options)
+		{
+			_options = options ?? throw new ArgumentNullException(nameof(options));
+		}
+
+		protected abstract PRTGMonitor InternalExecute(IConnectionMultiplexer connection, string parameter, MonitorCacheValueTransformEnum? transform);
+
+		public PRTGMonitor Execute(string parameter, MonitorCacheValueTransformEnum? transform)
+		{
+			// prepare connection
+			// TODO: use a factory, for mocking/tests purpose
+			using (var connection = ConnectionMultiplexer.Connect(_options))
+			{
+				return InternalExecute(connection, parameter, transform);
+			}
+		}
+	}
+}

--- a/Services/Factories/IRedisMonitorServiceFactory.cs
+++ b/Services/Factories/IRedisMonitorServiceFactory.cs
@@ -1,0 +1,15 @@
+﻿using PRTG_Redis_Sensor.Enums;
+
+namespace PRTG_Redis_Sensor.Services.Factories
+{
+	public interface IRedisMonitorServiceFactory
+	{
+		/// </summary>
+		/// <param name="endPoints">Redis endpoint separated by semicolon</param>
+		/// <param name="password">Redis password</param>
+		/// <param name="databaseIndex">Redis default database to be usedonnect</param>
+		/// <param name="cacheKeys">Keys whose values you want to retrieve from cache (separated by pipe | )</param>
+		/// <returns></returns>
+		IRedisMonitorService Create(string endPoints, string password, int? databaseIndex, MonitorServiceEnum monitorType);
+	}
+}

--- a/Services/Factories/RedisMonitorServiceFactory.cs
+++ b/Services/Factories/RedisMonitorServiceFactory.cs
@@ -1,0 +1,35 @@
+﻿using PRTG_Redis_Sensor.Enums;
+using PRTG_Redis_Sensor.Services.Impl;
+using StackExchange.Redis;
+
+namespace PRTG_Redis_Sensor.Services.Factories
+{
+	public class RedisMonitorServiceFactory : IRedisMonitorServiceFactory
+	{
+		/// <inheritdoc/>
+		public IRedisMonitorService Create(string endPoints, string password, int? databaseIndex, MonitorServiceEnum monitorType)
+		{
+			ConfigurationOptions options = new()
+			{
+				EndPoints = { { endPoints } },
+				AllowAdmin = true,
+				DefaultDatabase = databaseIndex
+			};
+
+			if (!string.IsNullOrEmpty(password))
+			{
+				options.Password = password;
+			}
+
+			switch (monitorType)
+			{
+				case MonitorServiceEnum.Stats:
+					return new StatsRedisMonitorService(options);
+				case MonitorServiceEnum.CacheKeysValues:
+					return new CacheValueRedisMonitorService(options);
+				default:
+					return new EmptyRedisMonitorService();
+			}
+		}
+	}
+}

--- a/Services/IRedisMonitorService.cs
+++ b/Services/IRedisMonitorService.cs
@@ -1,0 +1,10 @@
+﻿using PRTG_Redis_Sensor.Enums;
+using PRTG_Redis_Sensor.Model;
+
+namespace PRTG_Redis_Sensor.Services
+{
+	public interface IRedisMonitorService
+	{
+		PRTGMonitor Execute(string parameter, MonitorCacheValueTransformEnum? transform);
+	}
+}

--- a/Services/Impl/CacheValueRedisMonitorService.cs
+++ b/Services/Impl/CacheValueRedisMonitorService.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Newtonsoft.Json;
+using PRTG_Redis_Sensor.Enums;
+using PRTG_Redis_Sensor.Model;
+using PRTG_Redis_Sensor.Services.Base;
+using PRTG_Redis_Sensor.Utilities;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+
+namespace PRTG_Redis_Sensor.Services.Impl
+{
+	/// <summary>
+	/// Retrieves a Redis key cache value
+	/// </summary>
+	public class CacheValueRedisMonitorService : BaseRedisMonitorService
+	{
+		public CacheValueRedisMonitorService(ConfigurationOptions options) : base(options) { }
+
+		protected override PRTGMonitor InternalExecute(IConnectionMultiplexer connection, string parameter, MonitorCacheValueTransformEnum? transform)
+		{
+			using RedisCache cache = new RedisCache(new RedisCacheOptions { ConfigurationOptions = _options });
+
+			if (string.IsNullOrEmpty(parameter))
+				return null;
+
+			string[] cacheKeys = parameter.Split("|");
+			List<PRTGResult> elements = new List<PRTGResult>();
+
+			foreach (var cacheKey in cacheKeys)
+			{
+				byte[] cacheValue = cache.Get(cacheKey);
+				string value = CastUtilities.ConvertToString(cacheValue);
+
+				if (transform.HasValue)
+				{
+					switch (transform.Value)
+					{
+						case MonitorCacheValueTransformEnum.ElapsedMinutes:
+							DateTime dateValue = JsonConvert.DeserializeObject<DateTime>(value);
+							value = Convert.ToInt64(DateTime.Now.Subtract(dateValue).TotalMinutes).ToString();
+							break;
+					}
+				}
+
+				elements.Add(new PRTGResult
+				{
+					Channel = cacheKey,
+					Unit = PRTGUnit.Custom,
+					Value = value,
+				});
+			}
+
+			return new PRTGMonitor
+			{
+				Response = new PRTGResponse
+				{
+					result = elements
+				}
+			};
+		}
+	}
+}

--- a/Services/Impl/EmptyRedisMonitorService.cs
+++ b/Services/Impl/EmptyRedisMonitorService.cs
@@ -1,0 +1,13 @@
+﻿using PRTG_Redis_Sensor.Enums;
+using PRTG_Redis_Sensor.Model;
+
+namespace PRTG_Redis_Sensor.Services.Impl
+{
+	public class EmptyRedisMonitorService : IRedisMonitorService
+	{
+		public PRTGMonitor Execute(string parameter, MonitorCacheValueTransformEnum? transform)
+		{
+			return new PRTGMonitor { };
+		}
+	}
+}

--- a/Services/Impl/StatsRedisMonitorService.cs
+++ b/Services/Impl/StatsRedisMonitorService.cs
@@ -1,0 +1,391 @@
+﻿using PRTG_Redis_Sensor.Enums;
+using PRTG_Redis_Sensor.Model;
+using PRTG_Redis_Sensor.Services.Base;
+using PRTG_Redis_Sensor.Utilities;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PRTG_Redis_Sensor.Services.Impl
+{
+	/// <summary>
+	/// Retrieves the Redis cluster generic statistics
+	/// </summary>
+	public class StatsRedisMonitorService : BaseRedisMonitorService
+	{
+		public StatsRedisMonitorService(ConfigurationOptions options) : base(options) { }
+
+		protected override PRTGMonitor InternalExecute(IConnectionMultiplexer connection, string parameter, MonitorCacheValueTransformEnum? transform)
+		{
+			IServer redisServer = connection.GetServer(_options.EndPoints[0]);
+
+			var info = redisServer.Info();
+			var serverInfo = info.SingleOrDefault(i => i.Key.Equals("Server", StringComparison.InvariantCultureIgnoreCase));
+			var clientsInfo = info.SingleOrDefault(i => i.Key.Equals("Clients", StringComparison.InvariantCultureIgnoreCase));
+			var memoryInfo = info.SingleOrDefault(i => i.Key.Equals("Memory", StringComparison.InvariantCultureIgnoreCase));
+			var persistenceInfo = info.SingleOrDefault(i => i.Key.Equals("Persistence", StringComparison.InvariantCultureIgnoreCase));
+			var statsInfo = info.SingleOrDefault(i => i.Key.Equals("Stats", StringComparison.InvariantCultureIgnoreCase));
+			var replicationInfo = info.SingleOrDefault(i => i.Key.Equals("Replication", StringComparison.InvariantCultureIgnoreCase));
+			var keyspaceInfo = info.SingleOrDefault(i => i.Key.Equals("Keyspace", StringComparison.InvariantCultureIgnoreCase));
+			var cpuInfo = info.SingleOrDefault(i => i.Key.Equals("CPU", StringComparison.InvariantCultureIgnoreCase));
+			var clusterInfo = info.SingleOrDefault(i => i.Key.Equals("Cluster", StringComparison.InvariantCultureIgnoreCase));
+
+			return new PRTGMonitor
+			{
+				Response = new PRTGResponse
+				{
+					result = new List<PRTGResult>
+					{
+						{
+							new PRTGResult
+							{
+								Channel = "Uptime",
+								Unit = PRTGUnit.TimeSeconds,
+								Value = serverInfo?.SingleOrDefault(i => i.Key.Equals("uptime_in_seconds")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Connected Clients",
+								Unit = PRTGUnit.Count,
+								Value = clientsInfo?.SingleOrDefault(i => i.Key.Equals("connected_clients")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Blocked Clients",
+								Unit = PRTGUnit.Count,
+								Value = clientsInfo?.SingleOrDefault(i => i.Key.Equals("blocked_clients")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used Memory",
+								Unit = PRTGUnit.BytesMemory,
+								Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("used_memory")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used Memory RSS",
+								Unit = PRTGUnit.BytesMemory,
+								Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("used_memory_rss")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used Memory Peak",
+								Unit = PRTGUnit.BytesMemory,
+								Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("used_memory_peak")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Memory Fragmentation Ratio",
+								Unit = PRTGUnit.Custom,
+								Value = memoryInfo?.SingleOrDefault(i => i.Key.Equals("mem_fragmentation_ratio")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult()
+							{
+								Channel = "RDB Changes Since Last Save",
+								Unit = PRTGUnit.Custom,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_changes_since_last_save")).Value == "ok" ? "1" : "0"
+							}
+						},
+						{
+							new PRTGResult()
+							{
+								Channel = "RDB Last Save Time",
+								Unit = PRTGUnit.Custom,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_last_save_time")).Value == "ok" ? "1" : "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "RDB Last Background Save Status",
+								Unit = PRTGUnit.Count,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_last_bgsave_status")).Value == "ok" ? "1" : "0",
+								ShowChart = "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "RDB Last Background Save Time in Seconds",
+								Unit = PRTGUnit.TimeSeconds,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("rdb_last_bgsave_time_sec")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "AOF Last Rewrite Time in Seconds",
+								Unit = PRTGUnit.TimeSeconds,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("aof_last_rewrite_time_sec")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "AOF Last Background Rewrite Status",
+								Unit = PRTGUnit.Count,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("aof_last_bgrewrite_status")).Value == "ok" ? "1" : "0",
+								ShowChart = "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "AOF Last Write Status",
+								Unit = PRTGUnit.Count,
+								Value = persistenceInfo?.SingleOrDefault(i => i.Key.Equals("aof_last_write_status")).Value == "ok" ? "1" : "0",
+								ShowChart = "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Total Connections Received",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_connections_received")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Total Commands Processed",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_commands_processed")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Instantaneous Operations per Second",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("instantaneous_ops_per_sec")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult()
+							{
+								Channel = "Instantaneous Input kbps",
+								Unit = PRTGUnit.BytesBandwidth,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("instantaneous_input_kbps")).Value ?? "0",
+                                Float = "1"
+                            }
+						},
+						{
+							new PRTGResult()
+							{
+								Channel = "Instantaneous Output kbps",
+								Unit = PRTGUnit.BytesBandwidth,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("instantaneous_output_kbps")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Total Net Input Bytes",
+								Unit = PRTGUnit.BytesBandwidth,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_net_input_bytes")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Total Net Output Bytes",
+								Unit = PRTGUnit.BytesBandwidth,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("total_net_output_bytes")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Rejected Connections",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("rejected_connections")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Pubsub Channels",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("pubsub_channels")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Pubsub Patterns",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("pubsub_patterns")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Is Master",
+								Unit = PRTGUnit.Count,
+								Value = replicationInfo.SingleOrDefault(i => i.Key.Equals("role")).Value.Equals("master", StringComparison.InvariantCultureIgnoreCase) ? "1" : "0",
+								ShowChart = "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Is Replication Backlog Active",
+								Unit = PRTGUnit.Count,
+								Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_active")).Value ?? "0",
+								ShowChart = "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Replication Backlog Size",
+								Unit = PRTGUnit.BytesMemory,
+								Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_size")).Value ?? "0"
+							}
+						}
+						,
+						{
+							new PRTGResult
+							{
+								Channel = "Replication Backlog First Size Byte Offset",
+								Unit = PRTGUnit.BytesMemory,
+								Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_first_byte_offset")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Replication Backlog Histlen",
+								Unit = PRTGUnit.BytesMemory,
+								Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("repl_backlog_histlen")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Connected Slaves",
+								Unit = PRTGUnit.Count,
+								Value = replicationInfo?.SingleOrDefault(i => i.Key.Equals("connected_slaves")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Keys",
+								Unit = PRTGUnit.Count,
+								Value = CastUtilities.SafeGetInt32(() => keyspaceInfo != null ? keyspaceInfo.SingleOrDefault(i => i.Key.Equals("db0")).Value.Split(',').Select(x => x.Split('=')).ToDictionary(x => x[0], x => x[1])["keys"] : "0")
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Keys Expires",
+								Unit = PRTGUnit.Count,
+								Value = CastUtilities.SafeGetInt32(() => keyspaceInfo != null ? keyspaceInfo.SingleOrDefault(i => i.Key.Equals("db0")).Value.Split(',').Select(x => x.Split('=')).ToDictionary(x => x[0], x => x[1])["expires"] : "0")
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Keyspace Hits",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Keyspace Misses",
+								Unit = PRTGUnit.Count,
+								Value = statsInfo?.SingleOrDefault(i => i.Key.Equals("keyspace_misses")).Value ?? "0"
+							}
+						},
+						{
+							new PRTGResult()
+							{
+								Channel = "Hit Rate",
+								Unit = PRTGUnit.Percent,
+								Value = CastUtilities.SafeGetFloat(() => statsInfo != null ?
+									(
+										(100.0 *
+										 Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) /
+										 (
+											 Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_hits")).Value) +
+											 Convert.ToDouble(statsInfo.SingleOrDefault(i => i.Key.Equals("keyspace_misses")).Value)
+										 ))
+									).ToString() : "0"
+								),
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used CPU Sys",
+								Unit = PRTGUnit.Custom,
+								Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_sys")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used CPU User",
+								Unit = PRTGUnit.Custom,
+								Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_user")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used CPU Sys Children",
+								Unit = PRTGUnit.Custom,
+								Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_sys_children")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Used CPU User Children",
+								Unit = PRTGUnit.Custom,
+								Value = cpuInfo?.SingleOrDefault(i => i.Key.Equals("used_cpu_user_children")).Value ?? "0",
+								Float = "1"
+							}
+						},
+						{
+							new PRTGResult
+							{
+								Channel = "Cluster Enabled",
+								Unit = PRTGUnit.Count,
+								Value = clusterInfo?.SingleOrDefault(i => i.Key.Equals("cluster_enabled")).Value ?? "0",
+								ShowChart = "0"
+							}
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Utilities/CastUtilities.cs
+++ b/Utilities/CastUtilities.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace PRTG_Redis_Sensor.Utilities
+{
+	public class CastUtilities
+	{
+		public static string SafeGetInt32(Func<string> func)
+		{
+			try
+			{
+				return func();
+			}
+			catch (Exception ex)
+			{
+				Trace.TraceError(ex.ToString());
+				return "0";
+			}
+		}
+
+		public static string SafeGetFloat(Func<string> func)
+		{
+			try
+			{
+				var result = func();
+				return result.Equals("NaN", StringComparison.InvariantCultureIgnoreCase) ? "0" : result;
+
+			}
+			catch (Exception ex)
+			{
+				Trace.TraceError(ex.ToString());
+				return "0";
+			}
+		}
+
+		public static string ConvertToString(byte[] cacheValue)
+		{
+			if (cacheValue == null || cacheValue.Length == 0)
+				return "";
+
+			return System.Text.UTF8Encoding.UTF8.GetString(cacheValue);
+		}
+	}
+}


### PR DESCRIPTION
Little code refactor
Added command line parameters (with help and parameters explaination)
Database index now can be specified
Possibility to retrieve a list of values based on a list of cache keys
Simple value transformation for retrieved values (ie for dates, we can retrieve automatically the elapsed minutes)
None of the previouse features has been removed, I simply put that under a specific command type.
Readme review: new samples and tool usage explaination + note on breaking changes